### PR TITLE
Use the already existing label

### DIFF
--- a/src/templates/backend.layout.templates.action.tpl
+++ b/src/templates/backend.layout.templates.action.tpl
@@ -9,7 +9,7 @@
 {form:{{ action }}}
 
     <div class="form-group title">
-        <label for="title">{$lblTitle|ucfirst}<abbr title="{$msgRequired}">*</abbr></label>
+        <label for="title">{$lblTitle|ucfirst}<abbr title="{$lblRequiredField}">*</abbr></label>
         <div>
             {$txtTitle}
             {$txtTitleError}


### PR DESCRIPTION
In the core a label for required fields is already present, it is more sane to use this label
