### PR TITLE
Make sure site_title doesn't get overwritten

### DIFF
--- a/src/templates/Version37/frontend.actions.index.php
+++ b/src/templates/Version37/frontend.actions.index.php
@@ -111,7 +111,7 @@ class {{ actionSafe }} extends FrontendBaseBlock
         );
         $this->header->addOpenGraphData(
             'site_name',
-            FrontendModel::getModuleSetting('core', 'site_title_' . FRONTEND_LANGUAGE, SITE_DEFAULT_TITLE),
+            FrontendModel::getModuleSetting('Core', 'site_title_' . FRONTEND_LANGUAGE, SITE_DEFAULT_TITLE),
             true
         );
         $this->header->addOpenGraphData(


### PR DESCRIPTION
When a module setting isn't, found, it get's overwritten by the default value (SITE_DEFAULT_TITLE in this case).

This fix makes sure it isn't overwritten.